### PR TITLE
Allow '.' to appear in package release strings.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,7 +26,7 @@
 # @author Tyler Langlois <tyler.langlois@elastic.co>
 #
 class kibana (
-  Variant[Enum['present', 'absent', 'latest'], Pattern[/^\d([.]\d+)*(-[\d\w]+)?$/]] $ensure,
+  Variant[Enum['present', 'absent', 'latest'], Pattern[/^\d([.]\d+)*(-[\d\w.]+)?$/]] $ensure,
   Hash[String[1], Variant[String[1], Integer, Boolean, Array, Hash]] $config,
   Boolean $manage_repo,
   Boolean $oss,

--- a/spec/classes/kibana_spec.rb
+++ b/spec/classes/kibana_spec.rb
@@ -111,7 +111,7 @@ describe 'kibana', :type => 'class' do
         describe 'parameter validation for' do
           describe 'ensure' do
             context 'valid parameter' do
-              %w[present absent latest 5.2.1 5.2.2-1 5.2.2-bpo1].each do |param|
+              %w[present absent latest 4.5.4-2.el7 5.2.1 5.2.2-1 5.2.2-bpo1].each do |param|
                 context param do
                   let(:params) { { :ensure => param } }
                   it { should compile.with_all_deps }


### PR DESCRIPTION
Packages for RedHat/CentOS commonly have versions like:
1.2.3-4.el7

Here's an example in the wild:
https://cbs.centos.org/koji/buildinfo?buildID=12210
The page contains: "Information for build kibana-4.5.4-2.el7"

...and locally-built packages may follow this pattern, as in the case I
encountered.

Without this change, such package versions fail input validation.

<!--

The following list of checkboxes are the prerequisites for getting your contribution accepted.
Please check them as they are completed.

-->

Pull request acceptance prerequisites:

- [N/A] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [N/A] Updated CHANGELOG.md with patch notes (if necessary)
- [N/A] Any relevant docs (README.markdown or inline documentation) updated (if necessary)
- [N/A] Updated CONTRIBUTORS (if you would like attribution)
- [ ] Tests pass CI
