### PR TITLE
Avoid leaking passwords in puppet apply in templates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Puppet 4.10.0 is the new minimum required version of Puppet.
 #### Features
 
 #### Fixes
+* Sensitize kibana.yaml configuration file to avoid leaking `elasticsearch.password` if present
 
 ## 6.3.1 (October 19, 2018)
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,5 +5,6 @@ Project Owner
 * Elastic (elastic)
 
 Contributors:
+Andrew Ernst (ernstae)
 Tyler Langlois (tylerjl)
 Simon Oxwell (soxwellfb)

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,7 +14,7 @@ class kibana::config {
 
   file { '/etc/kibana/kibana.yml':
     ensure  => $_ensure,
-    content => template("${module_name}/etc/kibana/kibana.yml.erb"),
+    content => Sensitive(template("${module_name}/etc/kibana/kibana.yml.erb")),
     owner   => 'kibana',
     group   => 'kibana',
     mode    => '0660',


### PR DESCRIPTION
Users may have `elasticsearch.password` key/value pair in the `kibana::config` hash and this file should be sensitized and not leaked when applying (and diff is output)

Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [x] Updated CHANGELOG.md with patch notes (if necessary)
- [x] Any relevant docs (README.markdown or inline documentation) updated (if necessary)
- [x] Updated CONTRIBUTORS (if you would like attribution)
- [ ] Tests pass CI
