### PR TITLE
Crossport hash.rb from elastic/puppet-elasticsearch

### DIFF
--- a/lib/puppet_x/elastic/hash.rb
+++ b/lib/puppet_x/elastic/hash.rb
@@ -63,9 +63,12 @@ module Puppet_X # rubocop:disable Naming/ClassAndModuleCamelCase
       # Override each_pair with a method that yields key/values in
       # sorted order.
       def each_pair
+        return to_enum(:each_pair) unless block_given?
+
         keys.sort.each do |key|
           yield key, self[key]
         end
+        self
       end
     end
   end

--- a/spec/unit/puppet_x/elastic/hash_spec.rb
+++ b/spec/unit/puppet_x/elastic/hash_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..', 'lib'))
+
+require 'puppet'
+require 'puppet_x/elastic/hash'
+
+describe Puppet_X::Elastic::SortedHash do
+  subject { { 'foo' => 1, 'bar' => 2 } }
+
+  describe 'each_pair' do
+    it { is_expected.to respond_to :each_pair }
+
+    it 'yields values' do
+      expect { |b| subject.each_pair(&b) }.to yield_control.exactly(2).times
+    end
+
+    it 'returns an Enumerator if not passed a block' do
+      expect(subject.each_pair).to be_an_instance_of(Enumerator)
+    end
+
+    it 'returns values' do
+      subject.each_pair.map { |k, v| [k, v] }.should == subject.to_a
+    end
+  end
+end


### PR DESCRIPTION
hash.rb is also used in elastic/puppet-elasticsearch. The files are
currently not the same which leads to environment leaking errors due to
the module being a PuppetX function.

This copies the content of the file form elastic/puppet-elasticsearch to
get around the environment leaking for now.

<!--

The following list of checkboxes are the prerequisites for getting your contribution accepted.
Please check them as they are completed.

-->

Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [ ] Updated CHANGELOG.md with patch notes (if necessary)
- [ ] Any relevant docs (README.markdown or inline documentation) updated (if necessary)
- [ ] Updated CONTRIBUTORS (if you would like attribution)
- [ ] Tests pass CI
