### PR TITLE
Allow empty string values in kibana::config

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,7 +27,7 @@
 #
 class kibana (
   Variant[Enum['present', 'absent', 'latest'], Pattern[/^\d([.]\d+)*(-[\d\w]+)?$/]] $ensure,
-  Hash[String[1], Variant[String[1], Integer, Boolean, Array, Hash]] $config,
+  Hash[String[1], Variant[String, Integer, Boolean, Array, Hash]] $config,
   Boolean $manage_repo,
   Boolean $oss,
   Optional[String] $package_source,

--- a/spec/classes/kibana_spec.rb
+++ b/spec/classes/kibana_spec.rb
@@ -159,7 +159,7 @@ describe 'kibana', type: 'class' do
 
             context 'with bad parameters' do
               {
-                'server.basePath' => '',
+                'server.basePath' => 4.2,
                 5601 => :undef,
                 '' => :undef
               }.each do |key, val|


### PR DESCRIPTION
https://www.elastic.co/guide/en/kibana/current/configuring-tls.html#configuring-tls-kib-es says:

> If you used elasticsearch-certutil to generate a PKCS#12 file and you did not specify a password, the file is encrypted, and you need to set server.ssl.truststore.password to an empty string.

This change enables me to use Puppet to set `server.ssl.truststore.password` to an empty string.

Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- ~~[ ] Updated CHANGELOG.md with patch notes (if necessary)~~ — not a significant change
- ~~[ ] Any relevant docs (README.markdown or inline documentation) updated~~ — not a significant change
- ~~[ ] Updated CONTRIBUTORS~~
- [x] Tests pass CI
