### PR TITLE
Drop versions of Puppet which have reached EOL; require puppet 6 or 7

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -51,7 +51,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.0 < 8.0.0"
+      "version_requirement": ">= 6.1.0 < 8.0.0"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -17,35 +17,28 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "7",
-        "8"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },
     {
       "operatingsystem": "Fedora",
       "operatingsystemrelease": [
-        "28"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "14.04",
-        "16.04"
       ]
     },
     {

--- a/metadata.json
+++ b/metadata.json
@@ -51,7 +51,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.0 < 6.0.0"
+      "version_requirement": ">= 4.10.0 < 8.0.0"
     }
   ]
 }


### PR DESCRIPTION
This PR also include:
* #49 
* #50 